### PR TITLE
emit for unprivileged DDL

### DIFF
--- a/util.py
+++ b/util.py
@@ -189,7 +189,7 @@ def extract_tagged_values(data, name, key_split_char='.', tag_list=None):
         return [(dict(), value) for value in values.values()]
 
     if type(values) is not dict:
-        return (_extract_tags(name, key_split_char, tag_list), values)
+        return [(_extract_tags(name, key_split_char, tag_list), values)]
 
     result = []
     for key, value in values.items():

--- a/util.py
+++ b/util.py
@@ -189,15 +189,12 @@ def extract_tagged_values(data, name, key_split_char='.', tag_list=None):
         return [(dict(), value) for value in values.values()]
 
     if type(values) is not dict:
-        return _extract_tagged_value(name, values, key_split_char, tag_list)
+        return (_extract_tags(name, key_split_char, tag_list), values)
 
     result = []
     for key, value in values.items():
-        result.append(_extract_tagged_value(key, value, key_split_char, tag_list))
+        result.append((_extract_tags(key, key_split_char, tag_list), value))
     return result
-
-def _extract_tagged_value(name, value, key_split_char, tag_list):
-    return (_extract_tags(name, key_split_char, tag_list), value)
 
 def _extract_tags(name, key_split_char='.', tag_list=None):
     if not tag_list:

--- a/vttablet_collectd.py
+++ b/vttablet_collectd.py
@@ -121,6 +121,10 @@ class Vttablet(util.BaseCollector):
             self.process_metric(json_data, 'TableACLPseudoDenied', 'counter', parse_tags=acl_tags)
             # Super users are exempt and are tracked by this
             self.process_metric(json_data, 'TableACLExemptCount', 'counter')
+            # Look for DDL executed by users not in migration group
+            for tags, value in self._extract_values(json_data, 'TableACLAllowed', acl_tags):
+                if tags['id'] == "DDL" and not tags['user'].startswith('migration.'):
+                    self.emitter.emit("UnprivilegedDDL", value, 'counter', tags)
 
         if self.include_heartbeat:
             self.process_metric(json_data, 'HeartbeatCumulativeLagNs', 'counter')


### PR DESCRIPTION
detect DDL by users without 'migration.' prefix; also clean up useless util method