### PR TITLE
add VTicketsBatchSize to vtickets vttablet metrics

### DIFF
--- a/vttablet_collectd.py
+++ b/vttablet_collectd.py
@@ -165,6 +165,7 @@ class Vttablet(util.BaseCollector):
             self.process_metric(json_data, 'VTicketsRefills', 'counter', parse_tags=table_tag)
             self.process_metric(json_data, 'VTicketsFailedRefills', 'counter', parse_tags=table_tag)
             self.process_metric(json_data, 'VTicketsBlockingRefills', 'counter', parse_tags=table_tag)
+            self.process_metric(json_data, 'VTicketsBatchSize', 'gauge', parse_tags=table_tag)
             query_timing_tags = ['Median', 'NinetyNinth']
             if "VTicketsServiceCallsTimings" in json_data:
                 timing_json = json_data["VTicketsServiceCallsTimings"]


### PR DESCRIPTION
https://git.hubteam.com/HubSpot/vitess-upstream/pull/41

This adds the batch size that the vttablet requests from the hublet service in as a metric, so we can see how it fluctuates in response to changing QPS