### PR TITLE
add table tag to override autoinc metric

### DIFF
--- a/vtgate_collectd.py
+++ b/vtgate_collectd.py
@@ -84,9 +84,9 @@ class Vtgate(util.BaseCollector):
                     self.process_timing_quartile_metric(timing_json, "TotalRequestTime")
 
         if self.include_override_autoinc_stats:
-            keyspace_tag = ['keyspaceName']
-            self.process_metric(json_data, 'AutoIncOverridden', 'counter', parse_tags=keyspace_tag)
-            self.process_metric(json_data, 'AutoIncAttemptedOverride', 'counter', parse_tags=keyspace_tag)
+            override_autoinc_tags = ['keyspaceName', 'table']
+            self.process_metric(json_data, 'AutoIncOverridden', 'counter', parse_tags=override_autoinc_tags)
+            self.process_metric(json_data, 'AutoIncAttemptedOverride', 'counter', parse_tags=override_autoinc_tags)
 
     def process_rates(self, json_data, metric_name, tag_name):
         rates = json_data[metric_name]


### PR DESCRIPTION
For https://git.hubteam.com/HubSpot/vitess-upstream/pull/45

This adds in the table tag into the override/attempted override metric