### PR TITLE
Add vtgate gateway module monitoring serving masters

### DIFF
--- a/vtgate_gateway_collectd.py
+++ b/vtgate_gateway_collectd.py
@@ -23,13 +23,14 @@ class VtgateGateway(util.BaseCollector):
 
         for keyspaceName, tablets in keyspaces.items():
             foundServingMaster = False
-            for tabletsForType in tablets:
-                if "MASTER" == tabletsForType["tabletType"]:
-                    for tablet in tabletsForType['tabletsStats']:
-                        if tablet['Up'] and tablet['Serving']:
-                            foundServingMaster = True
-                            break
-            self.emitter.emit("servingMaster", 1 if foundServingMaster else 0, 'gauge', {"ks": tabletsForType["keyspace"], "shard": tabletsForType["shard"]})
+            if tablets:
+                for tabletsForType in tablets:
+                    if "MASTER" == tabletsForType["tabletType"]:
+                        for tablet in tabletsForType['tabletsStats']:
+                            if tablet['Up'] and tablet['Serving']:
+                                foundServingMaster = True
+                                break
+                self.emitter.emit("servingMaster", 1 if foundServingMaster else 0, 'gauge', {"ks": tabletsForType["keyspace"], "shard": tabletsForType["shard"]})
 
 
 def group_tablets_by_keyspace(json_data):

--- a/vtgate_gateway_collectd.py
+++ b/vtgate_gateway_collectd.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+
+import time
+import util
+import mock
+
+NAME = 'vtgate'
+
+#Module that generates metric using the vtgate /debug/gateways endpoint
+#Metrics generated
+# For all keyspace shards  servingMaster: 1/0 indicating whether there is a Master tablet up and serving
+class VtgateGateway(util.BaseCollector):
+    def __init__(self, collectd, json_provider=None, verbose=False, interval=None):
+        super(VtgateGateway, self).__init__(collectd, NAME, 15001, json_provider, verbose, interval)
+
+    def configure_callback(self, conf):
+        super(VtgateGateway, self).configure_callback(conf)
+        self.register_read_callback()
+
+    def process_data(self, json_data):
+       for keyspaceShardTabletType, tablets in json_data.items():
+          if "MASTER" in keyspaceShardTabletType:
+            foundServing = False
+            for tablet in tablets['TabletsStats']:
+                if tablet['Up'] and tablet['Serving']:
+                    foundServing = True
+                    break
+            self.emitter.emit("servingMaster", 1 if foundServing else 0, 'gauge', {"ks": tablets['Target']['keyspace'], "shard": tablets['Target']['shard']})
+            
+
+if __name__ == '__main__':
+    util.run_local(NAME, VtgateGateway)
+else:
+    import collectd
+    vt = VtgateGateway(collectd)
+    collectd.register_config(vt.configure_callback)


### PR DESCRIPTION
This PR adds a new module capable of extracting metrics from the vtgate  `/debug/gateway` endpoint. 

In each current form this module tracks whether master tablets are serving or not.
It emits a gauge `servingMaster: 0/1` with tags `[ks={keyspace}, shard={shard}]`. This gauge is emitted for all keyspace shards known to the vtgate.

